### PR TITLE
feature: React Routerのチュートリアル実施

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,16 @@
-import React from "react";
-import MainNavigation from "./component/MainNavigation/MainNavigation";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <div>Hello World!</div>,
+  },
+]);
 
 function App() {
-  return <MainNavigation />;
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,53 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import {
-  createBrowserRouter,
-  RouterProvider,
-  Route,
-  Navigate,
-} from "react-router-dom";
 import "./index.css";
 import App from "./App";
-import { About } from "./component/About/About";
 import reportWebVitals from "./reportWebVitals";
-import { Login } from "./component/Login/Login";
-
-// 開発モードのときはAPIモックを起動する
-if (process.env.NODE_ENV === "development") {
-  const { worker } = require("./mocks/browser");
-  worker.start();
-}
-
-// 認証情報を持っているかチェックする
-const CheckAuth = () => {
-  return sessionStorage.getItem("is-authenticated") ? (
-    <Route path="/" />
-  ) : (
-    <Navigate to="/login" replace />
-  );
-};
-
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <CheckAuth />,
-  },
-  {
-    path: "/login",
-    element: <Login />,
-  },
-  {
-    path: "/about",
-    element: <About />,
-  },
-]);
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <App />
   </React.StrictMode>
 );
 


### PR DESCRIPTION

- ルーターをWebアプリケーションに追加するためには`createBrowserRouter`を使う
- `RouterProvider`コンポーネントが`createBrowserRouter`のルーティング定義を読み込んでレンダリングする

App.tsx的なところにルーティング以外のロジックを書かない方が良さそう。
ルーティングの仕組みを取り替えるときにルーティング / それ以外を選り分けて取り外すのが大変になるため。

https://reactrouter.com/en/main/start/tutorial#adding-a-router
https://reactrouter.com/en/main/routers/router-provider