### PR TITLE
React Router チュートリアルのClient Side Routingを実施

### DIFF
--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, Link } from "react-router-dom";
 export default function Root() {
   return (
     <>
@@ -23,10 +23,10 @@ export default function Root() {
         <nav>
           <ul>
             <li>
-              <a href={`/contacts/1`}>Your Name</a>
+              <Link to={`/contacts/1`}>Your Name</Link>
             </li>
             <li>
-              <a href={`/contacts/2`}>Your Friend</a>
+              <Link to={`/contacts/2`}>Your Friend</Link>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
`<a>`タグを使って内部リンクを試みると毎回サーバーへ`<a>`タグのコンテンツを取得する。
`<Link>`を使うとコンテンツを再取得せず、SPAとしてページ遷移できる。

レンダリング結果は`<a>`タグ扱いとなる。
<img width="1080" alt="render" src="https://github.com/MofuMofu2/react-sandbox/assets/25704937/e48662ce-3d76-49ae-8867-2c17da10ff5c">
🤔 

チャンクが分かれている箇所は`<a>`で実施→コンテンツを取得
チャンクを分けていない（`id`とか）場合は`<Link>`で実施、という感じで使い分ける方がいいのか？

https://reactrouter.com/en/main/components/link