### PR TITLE
React RouterのUpdating dataを実施

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import Root, {
 } from "./routes/root";
 import ErrorPage from "./error-page";
 import Contact, { loader as contactLoader } from "./routes/contact";
-import EditContact from "./routes/edit";
+import EditContact, { action as editAction } from "./routes/edit";
 
 const router = createBrowserRouter([
   {
@@ -27,6 +27,7 @@ const router = createBrowserRouter([
         path: "contacts/:contactId/edit",
         element: <EditContact />,
         loader: contactLoader,
+        action: editAction,
       },
     ],
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Root, {
 } from "./routes/root";
 import ErrorPage from "./error-page";
 import Contact, { loader as contactLoader } from "./routes/contact";
+import EditContact from "./routes/edit";
 
 const router = createBrowserRouter([
   {
@@ -20,6 +21,11 @@ const router = createBrowserRouter([
       {
         path: "contacts/:contactId",
         element: <Contact />,
+        loader: contactLoader,
+      },
+      {
+        path: "contacts/:contactId/edit",
+        element: <EditContact />,
         loader: contactLoader,
       },
     ],

--- a/src/routes/edit.tsx
+++ b/src/routes/edit.tsx
@@ -1,4 +1,12 @@
-import { Form, useLoaderData } from "react-router-dom";
+import { Form, useLoaderData, redirect } from "react-router-dom";
+import { updateContact } from "../contacts";
+
+export async function action({ request, params }: any) {
+  const formData = await request.formData(); // フォーム内容を送信するためFormDataオブジェクトを作成
+  const updates = Object.fromEntries(formData); // データをオブジェクトに変換
+  await updateContact(params.contactId, updates); // リクエスト処理
+  return redirect(`/contacts/${params.contactId}`); // contactページにリダイレクト
+}
 
 export default function EditContact() {
   const { contact } = useLoaderData() as any;

--- a/src/routes/edit.tsx
+++ b/src/routes/edit.tsx
@@ -1,0 +1,55 @@
+import { Form, useLoaderData } from "react-router-dom";
+
+export default function EditContact() {
+  const { contact } = useLoaderData() as any;
+
+  return (
+    <Form method="post" id="contact-form">
+      <p>
+        <span> Name</span>
+        <input
+          placeholder="First"
+          name="first"
+          aria-label="First name"
+          type="text"
+          defaultValue={contact.first}
+        />
+        <input
+          placeholder="Last"
+          name="last"
+          aria-label="Last name"
+          type="text"
+          defaultValue={contact.last}
+        />
+      </p>
+      <label>
+        <span>Twitter</span>
+        <input
+          placeholder="Twitter"
+          name="twitter"
+          aria-label="Twitter handle"
+          type="text"
+          defaultValue={contact.twitter}
+        />
+      </label>
+      <label>
+        <span>Avatar URL</span>
+        <input
+          placeholder="Avatar URL"
+          name="avatar"
+          aria-label="Avatar URL"
+          type="text"
+          defaultValue={contact.avatar}
+        />
+      </label>
+      <label>
+        <span>Notes</span>
+        <textarea name="notes" defaultValue={contact.notes} rows={6}></textarea>
+      </label>
+      <p>
+        <button type="submit">Save</button>
+        <button type="button">Cancel</button>
+      </p>
+    </Form>
+  );
+}


### PR DESCRIPTION
Formとactionの組み合わせでボタンがsubmitされたときにリクエスト処理などを呼び出せる。
今回だと次のような流れになっている。

1. Request.formData()オブジェクトを生成
2. Object.formEntries()でパラメータをオブジェクト形式に変換
3. 擬似リクエスト処理でフォーム内のデータを更新
4. redirectでcontact/:contactIdページにリダイレクト

3は関数に切り出しておけば、将来的にルーティングライブラリを取り替えても影響を少なめにできると思われる。
それ以外はルーティングに紐づく処理なので依存するのは仕方なしか。

参考URL

- https://reactrouter.com/en/main/start/tutorial#updating-contacts-with-formdata
- https://developer.mozilla.org/ja/docs/Web/API/FormData/Using_FormData_Objects
- https://reactrouter.com/en/main/hooks/use-route-loader-data
- https://reactrouter.com/en/main/fetch/redirect
- https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries
- https://developer.mozilla.org/ja/docs/Web/API/FormData/Using_FormData_Objects