### PR TITLE
Global Pending UIを実施

### DIFF
--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -1,6 +1,7 @@
 import {
   Outlet,
   useLoaderData,
+  useNavigation,
   Form,
   NavLink,
   redirect,
@@ -20,6 +21,7 @@ export async function action() {
 
 export default function Root() {
   const contacts = useLoaderData() as any[];
+  const navigation = useNavigation();
   return (
     <>
       <div id="sidebar">
@@ -77,7 +79,10 @@ export default function Root() {
           )}
         </nav>
       </div>
-      <div id="detail">
+      <div
+        id="detail"
+        className={navigation.state === "loading" ? "loading" : ""}
+      >
         <Outlet />
       </div>
     </>


### PR DESCRIPTION
useNavigation()フックを使うと、（GETの場合）次のルーティング定義のloaderを呼び出している場合は`loading`ステータスとなる。今のページから次のページに移りたいが操作はさせたくない、というようなときに`useNavigation()`を使って制御できる。

GET以外は`submitting`で制御できる。

- https://reactrouter.com/en/main/hooks/use-navigation
- https://reactrouter.com/en/main/start/tutorial#global-pending-ui
