### PR TITLE
Deleting Recordsを実施

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Root, {
 import ErrorPage from "./error-page";
 import Contact, { loader as contactLoader } from "./routes/contact";
 import EditContact, { action as editAction } from "./routes/edit";
+import { action as destroyAction } from "./routes/destroy";
 
 const router = createBrowserRouter([
   {
@@ -27,6 +28,10 @@ const router = createBrowserRouter([
         element: <EditContact />,
         loader: contactLoader,
         action: editAction,
+      },
+      {
+        path: "contacts/:contactId/destroy",
+        action: destroyAction,
       },
     ],
   },

--- a/src/routes/contact.tsx
+++ b/src/routes/contact.tsx
@@ -52,7 +52,7 @@ export default function Contact() {
           <Form action="edit">
             <button type="submit">Edit</button>
           </Form>
-          <Form method="post" action="destory" onSubmit={() => {}}>
+          <Form method="post" action="destroy" onSubmit={() => {}}>
             <button type="submit">Delete</button>
           </Form>
         </div>

--- a/src/routes/destroy.tsx
+++ b/src/routes/destroy.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "react-router-dom";
+import { deleteContact } from "../contacts";
+
+export async function action({ params }: any) {
+  await deleteContact(params.contactId);
+  return redirect("/");
+}


### PR DESCRIPTION
`<Form>`を使うと、ブラウザの`<form>`の挙動を止めて内部的にReact Routerがルーティング処理を差し込めるようになる。

1. クライアントサイドで`<Form method="post">`のリクエストを生成
2. `contacts/:contactId/destroy`にルーティングする
3. <Form action="destroy">`のActionに一致する
4. destory.tsxのactionの処理を呼び出す

- https://reactrouter.com/en/main/components/form
- https://reactrouter.com/en/main/start/tutorial#deleting-records