### PR TITLE
Cancel Buttonチュートリアルを実施

### DIFF
--- a/src/routes/edit.tsx
+++ b/src/routes/edit.tsx
@@ -1,4 +1,4 @@
-import { Form, useLoaderData, redirect } from "react-router-dom";
+import { Form, useLoaderData, redirect, useNavigate } from "react-router-dom";
 import { updateContact } from "../contacts";
 
 export async function action({ request, params }: any) {
@@ -10,6 +10,7 @@ export async function action({ request, params }: any) {
 
 export default function EditContact() {
   const { contact } = useLoaderData() as any;
+  const navigate = useNavigate();
 
   return (
     <Form method="post" id="contact-form">
@@ -56,7 +57,14 @@ export default function EditContact() {
       </label>
       <p>
         <button type="submit">Save</button>
-        <button type="button">Cancel</button>
+        <button
+          type="button"
+          onClick={() => {
+            navigate(-1);
+          }}
+        >
+          Cancel
+        </button>
       </p>
     </Form>
   );


### PR DESCRIPTION
useNavigate() hookを用いてキャンセルボタンを押すと一つ前のページに戻る実装を実施している。
ドキュメントにもあるが、基本は`-1`でどこに飛ぶかわからないので明確にredirectなどで遷移先を指定する方が良い。

キャンセルボタンは`type=button`でただのボタン（遷移イベントが走らない）であることと、直接キャンセルのリンクを踏んでいるわけではない（ボタンをクリックしないと呼び出せない）のでuseNavigateを使っても問題は起こりにくい。

基本、そのくらいしか用途はないとも考えられる。



Vue.jsのVue Routerの[router.go](https://v3.router.vuejs.org/ja/guide/essentials/navigation.html)(-1)と同じような印象を受ける。

- https://reactrouter.com/en/main/start/tutorial#cancel-button
- https://reactrouter.com/en/main/hooks/use-navigate