### PR TITLE
Not found dataから最後までReact Routerのチュートリアルを実施

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,23 +22,28 @@ const router = createBrowserRouter([
     loader: rootLoader,
     action: rootAction,
     children: [
-      { index: true, element: <Index /> },
       {
-        path: "contacts/:contactId",
-        element: <Contact />,
-        loader: contactLoader,
-        action: contactAction,
-      },
-      {
-        path: "contacts/:contactId/edit",
-        element: <EditContact />,
-        loader: contactLoader,
-        action: editAction,
-      },
-      {
-        path: "contacts/:contactId/destroy",
-        action: destroyAction,
-        errorElement: <div>Oops! There was an error.</div>,
+        errorElement: <ErrorPage />,
+        children: [
+          { index: true, element: <Index /> },
+          {
+            path: "contacts/:contactId",
+            element: <Contact />,
+            loader: contactLoader,
+            action: contactAction,
+          },
+          {
+            path: "contacts/:contactId/edit",
+            element: <EditContact />,
+            loader: contactLoader,
+            action: editAction,
+          },
+          {
+            path: "contacts/:contactId/destroy",
+            action: destroyAction,
+            errorElement: <div>Oops! There was an error.</div>,
+          },
+        ],
       },
     ],
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import {
+  createRoutesFromElements,
+  createBrowserRouter,
+  Route,
+  RouterProvider,
+} from "react-router-dom";
 import "./index.css";
 import Index from "./routes";
 import Root, {
@@ -14,40 +19,34 @@ import Contact, {
 import EditContact, { action as editAction } from "./routes/edit";
 import { action as destroyAction } from "./routes/destroy";
 
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <Root />,
-    errorElement: <ErrorPage />,
-    loader: rootLoader,
-    action: rootAction,
-    children: [
-      {
-        errorElement: <ErrorPage />,
-        children: [
-          { index: true, element: <Index /> },
-          {
-            path: "contacts/:contactId",
-            element: <Contact />,
-            loader: contactLoader,
-            action: contactAction,
-          },
-          {
-            path: "contacts/:contactId/edit",
-            element: <EditContact />,
-            loader: contactLoader,
-            action: editAction,
-          },
-          {
-            path: "contacts/:contactId/destroy",
-            action: destroyAction,
-            errorElement: <div>Oops! There was an error.</div>,
-          },
-        ],
-      },
-    ],
-  },
-]);
+const router = createBrowserRouter(
+  createRoutesFromElements(
+    <Route
+      path="/"
+      loader={rootLoader}
+      action={rootAction}
+      element={<Root />}
+      errorElement={<ErrorPage />}
+    >
+      <Route errorElement={<ErrorPage />}>
+        <Route index element={<Index />} />
+        <Route
+          path="contacts/:contactId"
+          loader={contactLoader}
+          action={contactAction}
+          element={<Contact />}
+        />
+        <Route
+          path="contacts/:contactId/edit"
+          action={editAction}
+          loader={contactLoader}
+          element={<EditContact />}
+        />
+        <Route path="contacts/:contactId/destroy" action={destroyAction} />
+      </Route>
+    </Route>
+  )
+);
 
 function App() {
   return <RouterProvider router={router} />;

--- a/src/routes/contact.tsx
+++ b/src/routes/contact.tsx
@@ -12,6 +12,12 @@ type Contact = {
 
 export async function loader({ params }: any) {
   const contact = await getContact(params.contactId);
+  if (!contact) {
+    throw new Response("", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
   return { contact };
 }
 


### PR DESCRIPTION
throw new Errorでエラーハンドリングしたとき`errorElement`を呼び出すことができる
ただしdata routerの中でしか効かない。

React Routerが提供している`<Route>`コンポーネントを使うとルーティング定義をコンポーネント風に実現できる

- https://reactrouter.com/en/main/start/tutorial#not-found-data
- https://reactrouter.com/en/main/route/error-element
- https://reactrouter.com/en/main/route/route