### PR TITLE
7-1　コンポーネント描画／破棄時に処理を実行する – 副作用フック

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,5 +21,9 @@
         "ecmaVersion": "latest",
         "sourceType": "module",
         "project": "./tsconfig.json"
+    },
+    "rules": {
+        "@typescript-eslint/consistent-type-definitions": "off",
+        "@typescript-eslint/explicit-function-return-type": "off",
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,6 @@
     },
     "rules": {
         "@typescript-eslint/consistent-type-definitions": "off",
-        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/explicit-function-return-type": "off"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "Hoge"
+  ]
+}

--- a/src/component/Hooks/HookEffect.test.tsx
+++ b/src/component/Hooks/HookEffect.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import HookEffect from "./HookEffect";
+import { render } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+import userEvent from "@testing-library/user-event";
+
+it("ボタンをクリックするとuseEffectの処理が実行される", async () => {
+  const event = userEvent.setup();
+  const screen = render(<HookEffect init={10} />);
+
+  // 初回のレンダリング結果
+  expect(screen.getByText("10 回クリックされた")).toBeInTheDocument();
+
+  await act(async () => {
+    // カウントボタンをクリックする
+    await event.click(screen.getByText("カウント"));
+  });
+
+  expect(screen.getByText("11 回クリックされた")).toBeInTheDocument();
+});

--- a/src/component/Hooks/HookEffect.tsx
+++ b/src/component/Hooks/HookEffect.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from "react";
+
+type HookEffectProps = {
+  init: number;
+};
+
+const sleep = (delay: number) => {
+  const start = Date.now();
+  while (true) {
+    if (Date.now() - start > 1000) {
+      break;
+    }
+  }
+};
+
+export default function HookEffect({ init }: HookEffectProps) {
+  const [count, setCount] = useState(0);
+  const [hoge, setHoge] = useState("hoge");
+
+  useEffect(() => {
+    sleep(2000);
+    setCount(init);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleClick = () => {
+    setCount(count + 1);
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          setHoge(Date.now().toString());
+        }}
+      >{`Hoge ${hoge}`}</button>
+      <button onClick={handleClick}>カウント</button>
+      <p>{`${count} 回クリックされた`}</p>
+    </>
+  );
+}

--- a/src/component/Hooks/HookEffect.tsx
+++ b/src/component/Hooks/HookEffect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useLayoutEffect, useState } from "react";
 
 type HookEffectProps = {
   init: number;
@@ -17,7 +17,7 @@ export default function HookEffect({ init }: HookEffectProps) {
   const [count, setCount] = useState(0);
   const [hoge, setHoge] = useState("hoge");
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     sleep(2000);
     setCount(init);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/component/Hooks/HookTimer.css
+++ b/src/component/Hooks/HookTimer.css
@@ -1,0 +1,4 @@
+.warn {
+  color: red;
+  font-weight: bold;
+}

--- a/src/component/Hooks/HookTimer.test.tsx
+++ b/src/component/Hooks/HookTimer.test.tsx
@@ -10,7 +10,10 @@ it("Propsで渡された値から1秒ずつカウントが減ること", async (
   await act(async () => {
     // 1秒待つ
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    // 9になっていることを確認する
-    expect(screen.getByText("現在のカウント9")).toBeInTheDocument();
   });
+
+  // Reactのstate更新が完了するのを待つ
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  // 9になっていることを確認する
+  expect(screen.getByText("現在のカウント9")).toBeInTheDocument();
 });

--- a/src/component/Hooks/HookTimer.test.tsx
+++ b/src/component/Hooks/HookTimer.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import HookTimer from "./HookTimer";
+import { render } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+
+it("Propsで渡された値から1秒ずつカウントが減ること", async () => {
+  const screen = render(<HookTimer init={10} />);
+  expect(screen.getByText("現在のカウント10")).toBeInTheDocument();
+
+  await act(async () => {
+    // 1秒待つ
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    // 9になっていることを確認する
+    expect(screen.getByText("現在のカウント9")).toBeInTheDocument();
+  });
+});

--- a/src/component/Hooks/HookTimer.tsx
+++ b/src/component/Hooks/HookTimer.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from "react";
+import "./HookTimer.css";
+
+type HookTimerProps = {
+  init: number;
+};
+
+export default function HookTimer({ init }: HookTimerProps) {
+  const [count, setCount] = useState(init);
+
+  useEffect(() => {
+    const t = setInterval(() => {
+      setCount((c: number) => c - 1);
+    }, 1000);
+    return () => {
+      clearInterval(t);
+    };
+  }, []);
+
+  return <div className={count < 0 ? "warn" : ""}>現在のカウント{count}</div>;
+}

--- a/src/component/Hooks/StateEffect.test.tsx
+++ b/src/component/Hooks/StateEffect.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import StateEffect from "./StateEffect";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act } from "react-dom/test-utils";
+
+it("countの値が変化するとuseEffectの処理が実行される", async () => {
+  const event = userEvent.setup();
+  const screen = render(<StateEffect init={0} />);
+
+  // 初回のレンダリング結果
+  expect(screen.getByText("0 回クリックされた")).toBeInTheDocument();
+
+  await act(async () => {
+    // カウントボタンをクリックする
+    await event.click(screen.getByText("カウント"));
+  });
+
+  expect(screen.getByText("1 回クリックされた")).toBeInTheDocument();
+});

--- a/src/component/Hooks/StateEffect.tsx
+++ b/src/component/Hooks/StateEffect.tsx
@@ -12,12 +12,16 @@ export default function StateEffect({ init }: StateEffectProps) {
     console.log(`count is ${count}`);
   }, [count]);
 
-  const handleClick = () => setCount(count + 1);
+  const handleClick = () => {
+    setCount(count + 1);
+  };
 
   return (
     <>
       <button
-        onClick={() => setHoge(Date.now().toString())}
+        onClick={() => {
+          setHoge(Date.now().toString());
+        }}
       >{`Hoge ${hoge}`}</button>
       <button onClick={handleClick}>カウント</button>
       <p>{`${count} 回クリックされた`}</p>

--- a/src/component/Hooks/StateEffect.tsx
+++ b/src/component/Hooks/StateEffect.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from "react";
+
+type StateEffectProps = {
+  init: number;
+};
+
+export default function StateEffect({ init }: StateEffectProps) {
+  const [count, setCount] = useState(init);
+  const [hoge, setHoge] = useState("hoge");
+
+  useEffect(() => {
+    console.log(`count is ${count}`);
+  }, [count]);
+
+  const handleClick = () => setCount(count + 1);
+
+  return (
+    <>
+      <button
+        onClick={() => setHoge(Date.now().toString())}
+      >{`Hoge ${hoge}`}</button>
+      <button onClick={handleClick}>カウント</button>
+      <p>{`${count} 回クリックされた`}</p>
+    </>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,13 +3,7 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import "./i18n";
 import reportWebVitals from "./reportWebVitals";
-import StateEffect from "./component/Hooks/StateEffect";
-
-if (process.env.NODE_ENV === "development") {
-  void import("./mocks/browser").then(({ worker }) => {
-    worker.start();
-  });
-}
+import HookTimer from "./component/Hooks/HookTimer";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
@@ -18,7 +12,7 @@ const root = ReactDOM.createRoot(
 root.render(
   <>
     <div id="dialog"></div>
-    <StateEffect init={0} />
+    <HookTimer init={10} />
   </>
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import "./i18n";
 import reportWebVitals from "./reportWebVitals";
-import HookTimer from "./component/Hooks/HookTimer";
+import HookEffect from "./component/Hooks/HookEffect";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
@@ -12,7 +12,7 @@ const root = ReactDOM.createRoot(
 root.render(
   <>
     <div id="dialog"></div>
-    <HookTimer init={10} />
+    <HookEffect init={10} />
   </>
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import "./i18n";
 import reportWebVitals from "./reportWebVitals";
-import PortalBasic from "./component/Portal/PortalBasic";
+import StateEffect from "./component/Hooks/StateEffect";
 
 if (process.env.NODE_ENV === "development") {
   void import("./mocks/browser").then(({ worker }) => {
@@ -18,7 +18,7 @@ const root = ReactDOM.createRoot(
 root.render(
   <>
     <div id="dialog"></div>
-    <PortalBasic />
+    <StateEffect init={0} />
   </>
 );
 


### PR DESCRIPTION
- useEffectの使い所はコンポーネント外の変更を検知して再レンダリングする必要があるとき
- 依存配列の中に挿入されたstateが変わると再レンダリングされる。無限ループに気をつける
- fetchするときとかくらい？
- 抜けるときは依存状態を初期化する必要があるのでreturn文が入ってるか注意
- useLayoutEffectは画面のレンダリング前に実行される。UXに影響するため基本はuseEffectを使う

