### PR TITLE
特定のファイルにフォーマッタをかける設定を試した

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,14 @@
   "semi": true,
   "singleQuote": false,
   "tabWidth": 2,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": "./src/i18n/translation/*.json",
+      "options": {
+        "parser": "json",
+        "plugins": ["prettier-plugin-sort-json"]
+      }
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "jest": "^28.1.2",
         "localforage": "^1.10.0",
         "match-sorter": "^6.3.1",
+        "prettier-plugin-sort-json": "^3.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^13.3.1",
@@ -19306,6 +19307,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prettier-plugin-sort-json": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sort-json/-/prettier-plugin-sort-json-3.1.0.tgz",
+      "integrity": "sha512-eIDEUjwzekiVd+oKrpd0aoACBTp5zOW71wDTNy+qQ5C9Q8oqt9n9wCm4F+SeRZbXfgblh/WYIguJynImlBXrvQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -37482,6 +37494,11 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "prettier-plugin-sort-json": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sort-json/-/prettier-plugin-sort-json-3.1.0.tgz",
+      "integrity": "sha512-eIDEUjwzekiVd+oKrpd0aoACBTp5zOW71wDTNy+qQ5C9Q8oqt9n9wCm4F+SeRZbXfgblh/WYIguJynImlBXrvQ=="
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "jest": "^28.1.2",
     "localforage": "^1.10.0",
     "match-sorter": "^6.3.1",
+    "prettier-plugin-sort-json": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^13.3.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "lint-staged": {
     "*.ts": "prettier --write",
     "*.tsx": "prettier --write",
-    "*.json": "npm run sort-json"
+    "*.json": "prettier --write"
   },
   "browserslist": {
     "production": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import {
   createBrowserRouter,
   createRoutesFromElements,
 } from "react-router-dom";
-import Root from "./routes/Root";
+import Root from "./routes/root";
 
 const router = createBrowserRouter(
   createRoutesFromElements(<Route path="/" element={<Root />}></Route>)


### PR DESCRIPTION
ポイント

- overridesを使う
- filesで対象パスを指定
- optionsにPrettierの設定を書く。なので特定のプラグインだけ設定したかったらpluginsを続けて書く。

ドキュメントの通りだけど、これがあることに辿り着けなかった。まとめておこう。
https://prettier.io/docs/en/configuration.html#configuration-overrides

https://github.com/MofuMofu2/rimarimadan-blog/issues/18