### PR TITLE
インポート文を自動ソート可能にした

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,10 +26,12 @@
         "groups": [
           "builtin",
           "external",
-          "internal",
           "parent",
+          "internal",
           "sibling",
-          "index"
+          "index",
+          "object",
+          "type"
         ],
         "alphabetize": { "order": "asc", "caseInsensitive": true }
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,8 +45,7 @@
           }
         ],
         "pathGroupsExcludedImportTypes": ["builtin"],
-        "alphabetize": { "order": "asc", "caseInsensitive": true },
-        "newlines-between": "always"
+        "alphabetize": { "order": "asc", "caseInsensitive": true }
       }
     ]
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,21 @@
   },
   "rules": {
     "@typescript-eslint/consistent-type-definitions": "off",
-    "@typescript-eslint/explicit-function-return-type": "off"
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index"
+        ],
+        "alphabetize": { "order": "asc", "caseInsensitive": true }
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,14 +26,27 @@
         "groups": [
           "builtin",
           "external",
-          "parent",
-          "internal",
-          "sibling",
           "index",
+          "type",
           "object",
-          "type"
+          "internal",
+          "sibling"
         ],
-        "alphabetize": { "order": "asc", "caseInsensitive": true }
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "external",
+            "position": "before"
+          },
+          {
+            "pattern": "@testing-library/**",
+            "group": "external",
+            "position": "before"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["builtin"],
+        "alphabetize": { "order": "asc", "caseInsensitive": true },
+        "newlines-between": "always"
       }
     ]
   },

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,18 @@
+const path = require('path');
+
+module.exports = {
+  '*.{ts,tsx}': (filenames) => {
+    const cwd = process.cwd();
+    const files = filenames.map((file) => path.relative(cwd, file));
+    return [
+      `npx eslint --fix --rule 'import/order: 2'`,
+      `npx prettier --write ${files.join(' ')}`,
+      `npx eslint ${files.join(' ')}`,
+    ];
+  },
+  '*.json': (filenames) => {
+    const cwd = process.cwd();
+    const files = filenames.map((file) => path.relative(cwd, file));
+    return [`npx prettier --write ${files.join(' ')}`];
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "eslint": "^8.19.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-config-standard-with-typescript": "^39.1.1",
-        "eslint-plugin-import": "^2.29.0",
+        "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-n": "^16.2.0",
         "eslint-plugin-prettier": "^5.0.1",
@@ -9290,9 +9290,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
-      "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -9310,7 +9310,7 @@
         "object.groupby": "^1.0.1",
         "object.values": "^1.1.7",
         "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
+        "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
@@ -22447,9 +22447,9 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.2",
@@ -30477,9 +30477,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
-      "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "requires": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -30497,7 +30497,7 @@
         "object.groupby": "^1.0.1",
         "object.values": "^1.1.7",
         "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
+        "tsconfig-paths": "^3.15.0"
       },
       "dependencies": {
         "debug": {
@@ -39774,9 +39774,9 @@
       "dev": true
     },
     "tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint": "^8.19.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-standard-with-typescript": "^39.1.1",
-    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-n": "^16.2.0",
     "eslint-plugin-prettier": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,6 @@
     "prepare": "husky install",
     "test": "react-scripts test --watchAll=false"
   },
-  "lint-staged": {
-    "*.ts": "prettier --write",
-    "*.tsx": "prettier --write",
-    "*.json": "prettier --write"
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
+
 import {
   Route,
   RouterProvider,
   createBrowserRouter,
   createRoutesFromElements,
 } from "react-router-dom";
+
 import Root from "./routes/root";
 
 const router = createBrowserRouter(

--- a/src/component/AddColorForm/AddColorForm.test.tsx
+++ b/src/component/AddColorForm/AddColorForm.test.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import { fireEvent, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 import AddColorForm from ".";
 
 it("タイトルフォームに値を入力するとフォームテキストにも反映される", async () => {

--- a/src/component/AddColorForm/AddColorForm.test.tsx
+++ b/src/component/AddColorForm/AddColorForm.test.tsx
@@ -1,6 +1,8 @@
+import React from "react";
+
 import { fireEvent, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
+
 import AddColorForm from ".";
 
 it("タイトルフォームに値を入力するとフォームテキストにも反映される", async () => {

--- a/src/component/AddColorForm/index.tsx
+++ b/src/component/AddColorForm/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useInput } from "../../hooks/inputHooks";
 import { useColors } from "../ColorProvider";
 

--- a/src/component/ChangeLanguage/ChangeLanguage.test.tsx
+++ b/src/component/ChangeLanguage/ChangeLanguage.test.tsx
@@ -1,8 +1,12 @@
-import { render } from "@testing-library/react";
 import React, { type ComponentType, useTransition } from "react";
+
+import { render } from "@testing-library/react";
+
 import { initReactI18next } from "react-i18next";
-import i18n from "../../i18n/i18n";
+
 import ChangeLanguage from "./ChangeLanguage";
+
+import i18n from "../../i18n/i18n";
 
 beforeEach(() => {
   i18n.use(initReactI18next).init({

--- a/src/component/ChangeLanguage/ChangeLanguage.test.tsx
+++ b/src/component/ChangeLanguage/ChangeLanguage.test.tsx
@@ -1,8 +1,8 @@
-import React, { type ComponentType, useTransition } from "react";
-import ChangeLanguage from "./ChangeLanguage";
 import { render } from "@testing-library/react";
-import i18n from "../../i18n/i18n";
+import React, { type ComponentType, useTransition } from "react";
 import { initReactI18next } from "react-i18next";
+import i18n from "../../i18n/i18n";
+import ChangeLanguage from "./ChangeLanguage";
 
 beforeEach(() => {
   i18n.use(initReactI18next).init({

--- a/src/component/Color/Color.test.tsx
+++ b/src/component/Color/Color.test.tsx
@@ -1,6 +1,6 @@
+import { render } from "@testing-library/react";
 import React from "react";
 import Color from ".";
-import { render } from "@testing-library/react";
 
 it("色を選ぶテキストがレンダリングされていること", () => {
   const content = render(<Color id="1" title="red" color="#f00" rating={3} />);

--- a/src/component/Color/Color.test.tsx
+++ b/src/component/Color/Color.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@testing-library/react";
 import React from "react";
+
+import { render } from "@testing-library/react";
+
 import Color from ".";
 
 it("色を選ぶテキストがレンダリングされていること", () => {

--- a/src/component/Color/index.tsx
+++ b/src/component/Color/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import StarRating from "../StarRating";
 
 export interface Colors {

--- a/src/component/ColorList/index.tsx
+++ b/src/component/ColorList/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import Color, { type Colors } from "../Color";
 import { useColors } from "../ColorProvider";
 

--- a/src/component/ColorProvider/index.tsx
+++ b/src/component/ColorProvider/index.tsx
@@ -1,5 +1,7 @@
 import React, { useState, createContext, useContext } from "react";
+
 import { v4 } from "uuid";
+
 import colorData from "../../assets/color-data.json";
 import { type Colors } from "../Color";
 

--- a/src/component/ColorProvider/index.tsx
+++ b/src/component/ColorProvider/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, createContext, useContext } from "react";
-import colorData from "../../assets/color-data.json";
 import { v4 } from "uuid";
+import colorData from "../../assets/color-data.json";
 import { type Colors } from "../Color";
 
 const ColorContext = createContext<any>(undefined);

--- a/src/component/EventMouse/EventMouse.tsx
+++ b/src/component/EventMouse/EventMouse.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
 import { faGrinStars } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, { useState } from "react";
 
 export default function EventMouse() {
   const [current, setCurrent] = useState<"blue" | "red">("blue");

--- a/src/component/EventMouse/EventMouse.tsx
+++ b/src/component/EventMouse/EventMouse.tsx
@@ -1,6 +1,7 @@
+import React, { useState } from "react";
+
 import { faGrinStars } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import React, { useState } from "react";
 
 export default function EventMouse() {
   const [current, setCurrent] = useState<"blue" | "red">("blue");

--- a/src/component/ForList/ForItem.tsx
+++ b/src/component/ForList/ForItem.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { type BookSrc } from "./ForList";
 
 interface ForItemProps {

--- a/src/component/ForList/ForList.tsx
+++ b/src/component/ForList/ForList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import ForItem from "./ForItem";
 interface ForListProps {
   src: BookSrc[];

--- a/src/component/Form/AnimalOptions.tsx
+++ b/src/component/Form/AnimalOptions.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { type Animal } from "./animal";
 
 export default function AnimalOptions({ name, value }: Animal) {

--- a/src/component/Form/FormList.tsx
+++ b/src/component/Form/FormList.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+
 import { animals } from "./animal";
 import AnimalOptions from "./AnimalOptions";
 

--- a/src/component/Form/FormSelect.tsx
+++ b/src/component/Form/FormSelect.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+
 import { animals } from "./animal";
 import AnimalOptions from "./AnimalOptions";
 

--- a/src/component/Hooks/Context/HookContext.test.tsx
+++ b/src/component/Hooks/Context/HookContext.test.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { render } from "@testing-library/react";
+import React from "react";
 import HookContext from "./HookContext";
 
 it("MyAppContextの値が子コンポーネントに渡されている", () => {

--- a/src/component/Hooks/Context/HookContext.test.tsx
+++ b/src/component/Hooks/Context/HookContext.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@testing-library/react";
 import React from "react";
+
+import { render } from "@testing-library/react";
+
 import HookContext from "./HookContext";
 
 it("MyAppContextの値が子コンポーネントに渡されている", () => {

--- a/src/component/Hooks/Context/HookContext.tsx
+++ b/src/component/Hooks/Context/HookContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext } from "react";
+
 import { HookContextChild } from "./HookContextChild";
 
 type MyAppContextType = {

--- a/src/component/Hooks/Context/HookContextChild.tsx
+++ b/src/component/Hooks/Context/HookContextChild.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+
 import { MyAppContext } from "./HookContext";
 
 export function HookContextChild() {

--- a/src/component/Hooks/memo/HookMemo.test.tsx
+++ b/src/component/Hooks/memo/HookMemo.test.tsx
@@ -1,7 +1,7 @@
-import React from "react";
 import { render } from "@testing-library/react";
-import HookMemo from "./HookMemo";
 import userEvent from "@testing-library/user-event";
+import React from "react";
+import HookMemo from "./HookMemo";
 
 it("初期値のテスト", () => {
   const content = render(<HookMemo />);

--- a/src/component/Hooks/memo/HookMemo.test.tsx
+++ b/src/component/Hooks/memo/HookMemo.test.tsx
@@ -1,6 +1,8 @@
+import React from "react";
+
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
+
 import HookMemo from "./HookMemo";
 
 it("初期値のテスト", () => {

--- a/src/component/Hooks/useEffect/HookEffect.test.tsx
+++ b/src/component/Hooks/useEffect/HookEffect.test.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import HookEffect from "./HookEffect";
 import { render } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
 import userEvent from "@testing-library/user-event";
+import React from "react";
+import { act } from "react-dom/test-utils";
+import HookEffect from "./HookEffect";
 
 it("ボタンをクリックするとuseEffectの処理が実行される", async () => {
   const event = userEvent.setup();

--- a/src/component/Hooks/useEffect/HookEffect.test.tsx
+++ b/src/component/Hooks/useEffect/HookEffect.test.tsx
@@ -1,7 +1,10 @@
+import React from "react";
+
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
+
 import { act } from "react-dom/test-utils";
+
 import HookEffect from "./HookEffect";
 
 it("ボタンをクリックするとuseEffectの処理が実行される", async () => {

--- a/src/component/Hooks/useEffect/HookTimer.test.tsx
+++ b/src/component/Hooks/useEffect/HookTimer.test.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import HookTimer from "./HookTimer";
 import { render } from "@testing-library/react";
+import React from "react";
 import { act } from "react-dom/test-utils";
+import HookTimer from "./HookTimer";
 
 describe("HookTimerに関するテスト", () => {
   beforeEach(() => {

--- a/src/component/Hooks/useEffect/HookTimer.test.tsx
+++ b/src/component/Hooks/useEffect/HookTimer.test.tsx
@@ -1,6 +1,9 @@
-import { render } from "@testing-library/react";
 import React from "react";
+
+import { render } from "@testing-library/react";
+
 import { act } from "react-dom/test-utils";
+
 import HookTimer from "./HookTimer";
 
 describe("HookTimerに関するテスト", () => {

--- a/src/component/Hooks/useEffect/StateEffect.test.tsx
+++ b/src/component/Hooks/useEffect/StateEffect.test.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import StateEffect from "./StateEffect";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 import { act } from "react-dom/test-utils";
+import StateEffect from "./StateEffect";
 
 it("countの値が変化するとuseEffectの処理が実行される", async () => {
   const event = userEvent.setup();

--- a/src/component/Hooks/useEffect/StateEffect.test.tsx
+++ b/src/component/Hooks/useEffect/StateEffect.test.tsx
@@ -1,7 +1,10 @@
+import React from "react";
+
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
+
 import { act } from "react-dom/test-utils";
+
 import StateEffect from "./StateEffect";
 
 it("countの値が変化するとuseEffectの処理が実行される", async () => {

--- a/src/component/Hooks/useReducer/HookReducer.test.tsx
+++ b/src/component/Hooks/useReducer/HookReducer.test.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import HookReducer from "./HookReducer";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
+import HookReducer from "./HookReducer";
 
 it("初期状態はpropsの値でpタグのテキストがレンダリングされる", () => {
   const screen = render(<HookReducer init={0} />);

--- a/src/component/Hooks/useReducer/HookReducer.test.tsx
+++ b/src/component/Hooks/useReducer/HookReducer.test.tsx
@@ -1,6 +1,8 @@
+import React from "react";
+
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
+
 import HookReducer from "./HookReducer";
 
 it("初期状態はpropsの値でpタグのテキストがレンダリングされる", () => {

--- a/src/component/Hooks/useReducer/HookReducerUp.test.tsx
+++ b/src/component/Hooks/useReducer/HookReducerUp.test.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import HookReducerUp from "./HookReducerUp";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
+import HookReducerUp from "./HookReducerUp";
 
 it("初期状態はpropsの値でpタグのテキストがレンダリングされる", () => {
   const screen = render(<HookReducerUp init={0} />);

--- a/src/component/Hooks/useReducer/HookReducerUp.test.tsx
+++ b/src/component/Hooks/useReducer/HookReducerUp.test.tsx
@@ -1,6 +1,8 @@
+import React from "react";
+
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
+
 import HookReducerUp from "./HookReducerUp";
 
 it("初期状態はpropsの値でpタグのテキストがレンダリングされる", () => {

--- a/src/component/Hooks/useRef/HookRefForward.tsx
+++ b/src/component/Hooks/useRef/HookRefForward.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+
 import MyTextBox from "./MyTextBox";
 
 export default function HookRefForward() {

--- a/src/component/Hooks/useRef/HookRefNg.test.tsx
+++ b/src/component/Hooks/useRef/HookRefNg.test.tsx
@@ -1,7 +1,7 @@
-import React from "react";
 import { act, render } from "@testing-library/react";
-import HookRefNg from "./HookRefNg";
 import userEvent from "@testing-library/user-event";
+import React from "react";
+import HookRefNg from "./HookRefNg";
 
 it("ボタンをクリックすると1秒ずつ待ち、開始ボタンを押すと秒数ごとにカウントする", async () => {
   const event = userEvent.setup();

--- a/src/component/Hooks/useRef/HookRefNg.test.tsx
+++ b/src/component/Hooks/useRef/HookRefNg.test.tsx
@@ -1,6 +1,8 @@
+import React from "react";
+
 import { act, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
+
 import HookRefNg from "./HookRefNg";
 
 it("ボタンをクリックすると1秒ずつ待ち、開始ボタンを押すと秒数ごとにカウントする", async () => {

--- a/src/component/ListTemplate/ListTemplate.tsx
+++ b/src/component/ListTemplate/ListTemplate.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { type BookSrc } from "../ForList/ForList";
 
 interface ListTemplateProps {

--- a/src/component/MainNavigation/MainNavigation.tsx
+++ b/src/component/MainNavigation/MainNavigation.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+
 import { Link } from "react-router-dom";
 import "./MainNavigation.css";
 

--- a/src/component/Portal/PortalBasic.tsx
+++ b/src/component/Portal/PortalBasic.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+
 import { createPortal } from "react-dom";
 import "./PortalBasic.css";
 

--- a/src/component/Profiler/ProfilerBasic.tsx
+++ b/src/component/Profiler/ProfilerBasic.tsx
@@ -1,4 +1,5 @@
 import React, { Profiler } from "react";
+
 import HeavyUI from "./HeavyUI";
 
 export default function ProfilerBasic() {

--- a/src/component/Recoil/RecoilCounter.test.tsx
+++ b/src/component/Recoil/RecoilCounter.test.tsx
@@ -1,7 +1,10 @@
+import React from "react";
+
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
+
 import { RecoilRoot } from "recoil";
+
 import RecoilCounter from "./RecoilCounter";
 
 it("初期状態は0回しかクリックされていない", () => {

--- a/src/component/Recoil/RecoilCounter.test.tsx
+++ b/src/component/Recoil/RecoilCounter.test.tsx
@@ -1,8 +1,8 @@
-import React from "react";
 import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
 import { RecoilRoot } from "recoil";
 import RecoilCounter from "./RecoilCounter";
-import userEvent from "@testing-library/user-event";
 
 it("初期状態は0回しかクリックされていない", () => {
   const content = render(

--- a/src/component/Recoil/RecoilCounter.tsx
+++ b/src/component/Recoil/RecoilCounter.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+
 import { useRecoilState } from "recoil";
+
 import { counterAtom } from "../../store/atom";
 
 export default function RecoilCounter() {

--- a/src/component/Star/Star.test.tsx
+++ b/src/component/Star/Star.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@testing-library/react";
 import React from "react";
+
+import { render } from "@testing-library/react";
+
 import Star from "./";
 
 it("選択状態のときは赤色でレンダリングされる", () => {

--- a/src/component/Star/Star.test.tsx
+++ b/src/component/Star/Star.test.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { render } from "@testing-library/react";
+import React from "react";
 import Star from "./";
 
 it("選択状態のときは赤色でレンダリングされる", () => {

--- a/src/component/Star/index.tsx
+++ b/src/component/Star/index.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { faStar } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import React from "react";
 
 interface StarProps {
   selected?: boolean;

--- a/src/component/Star/index.tsx
+++ b/src/component/Star/index.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import { faStar } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React from "react";
 
 interface StarProps {
   selected?: boolean;

--- a/src/component/StarRating/StarRating.test.tsx
+++ b/src/component/StarRating/StarRating.test.tsx
@@ -1,5 +1,7 @@
-import { render } from "@testing-library/react";
 import React from "react";
+
+import { render } from "@testing-library/react";
+
 import StarRating from "./";
 
 it("初期状態", () => {

--- a/src/component/StarRating/StarRating.test.tsx
+++ b/src/component/StarRating/StarRating.test.tsx
@@ -1,7 +1,7 @@
-import React from "react";
 import { getAllByTitle, render } from "@testing-library/react";
-import StarRating from "./";
 import userEvent from "@testing-library/user-event";
+import React from "react";
+import StarRating from "./";
 
 it("初期状態", () => {
   const screen = render(<StarRating />);

--- a/src/component/StarRating/StarRating.test.tsx
+++ b/src/component/StarRating/StarRating.test.tsx
@@ -1,5 +1,4 @@
-import { getAllByTitle, render } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render } from "@testing-library/react";
 import React from "react";
 import StarRating from "./";
 

--- a/src/component/StarRating/index.tsx
+++ b/src/component/StarRating/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import Star from "../Star";
 export default function StarRating({
   totalStars = 5,

--- a/src/component/Suspense/ThrowResult.tsx
+++ b/src/component/Suspense/ThrowResult.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+
 import { wrapPromise } from "./wrapPromise";
 
 export default function ThrowResult() {

--- a/src/component/Todo/Todo.test.tsx
+++ b/src/component/Todo/Todo.test.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { render } from "@testing-library/react";
+import React from "react";
 import { RecoilRoot } from "recoil";
 import "@testing-library/jest-dom";
 

--- a/src/component/Todo/Todo.test.tsx
+++ b/src/component/Todo/Todo.test.tsx
@@ -1,7 +1,9 @@
-import { render } from "@testing-library/react";
 import React from "react";
-import { RecoilRoot } from "recoil";
+
+import { render } from "@testing-library/react";
 import "@testing-library/jest-dom";
+
+import { RecoilRoot } from "recoil";
 
 import Todo from "./Todo";
 

--- a/src/component/Todo/Todo.tsx
+++ b/src/component/Todo/Todo.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import "./Todo.modules.css";
 import { useRecoilState, useRecoilValue } from "recoil";
-import { todoLastIdSelector } from "../../store/selector";
 import { type TodoList, todoAtom } from "../../store/atom";
+import { todoLastIdSelector } from "../../store/selector";
 
 export default function Todo() {
   const [title, setTitle] = useState("");

--- a/src/component/Todo/Todo.tsx
+++ b/src/component/Todo/Todo.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
+
 import "./Todo.modules.css";
 import { useRecoilState, useRecoilValue } from "recoil";
+
 import { type TodoList, todoAtom } from "../../store/atom";
 import { todoLastIdSelector } from "../../store/selector";
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+
 import ReactDOM from "react-dom/client";
+
 import "./index.css";
 import HookMemo from "./component/Hooks/memo/HookMemo";
 import reportWebVitals from "./reportWebVitals";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
-import reportWebVitals from "./reportWebVitals";
 import HookMemo from "./component/Hooks/memo/HookMemo";
+import reportWebVitals from "./reportWebVitals";
 
 async function enableMocking() {
   if (process.env.NODE_ENV !== "development") {

--- a/src/routes/contact.tsx
+++ b/src/routes/contact.tsx
@@ -1,4 +1,5 @@
 import { Form, useLoaderData, useFetcher } from "react-router-dom";
+
 import { getContact, updateContact } from "../contacts";
 
 interface Contact {

--- a/src/routes/destroy.tsx
+++ b/src/routes/destroy.tsx
@@ -1,5 +1,7 @@
 import { error } from "console";
+
 import { redirect } from "react-router-dom";
+
 import { deleteContact } from "../contacts";
 
 export async function action({ params }: any) {

--- a/src/routes/destroy.tsx
+++ b/src/routes/destroy.tsx
@@ -1,6 +1,6 @@
+import { error } from "console";
 import { redirect } from "react-router-dom";
 import { deleteContact } from "../contacts";
-import { error } from "console";
 
 export async function action({ params }: any) {
   throw new Error("Not implemented");

--- a/src/routes/edit.tsx
+++ b/src/routes/edit.tsx
@@ -1,4 +1,5 @@
 import { Form, useLoaderData, redirect, useNavigate } from "react-router-dom";
+
 import { updateContact } from "../contacts";
 
 export async function action({ request, params }: any) {

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
-import i18n from "../i18n/i18n";
 import { useTranslation } from "react-i18next";
+import i18n from "../i18n/i18n";
 
 interface Data {
   username: "string";

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from "react";
+
 import { useTranslation } from "react-i18next";
+
 import i18n from "../i18n/i18n";
 
 interface Data {


### PR DESCRIPTION
## 概要

まだあまりわかってないところもあるのでGPTに解説してもらった。


`.eslintrc.json` ファイル内の `import/order` ルールに基づいて、インポート文がどのような順番で並ぶかを説明します。

### `import/order` ルールの設定

- **`groups`**:
  - `builtin`: Node.js の組み込みモジュール。
  - `external`: `node_modules` からの外部モジュール。
  - `index`: 現在のディレクトリのインデックスファイル（`index.js`/`index.ts`）。
  - `type`: TypeScriptの型定義のインポート。
  - `object`: `import` 文で `{}` を使用していないその他のインポート。
  - `internal`: プロジェクト内のカスタムパスやエイリアスを使用したモジュール。
  - `sibling`: 同じディレクトリ内のファイル。

- **`pathGroups`**:
  - 特定のパターン（`react` および `@testing-library/**`）に一致する外部モジュールを、他の `external` グループより前に配置。

- **`alphabetize`**: インポート文をアルファベット順（昇順、大文字・小文字を区別しない）で並べ替えます。

- **`pathGroupsExcludedImportTypes`**: `builtin` タイプのインポートは `pathGroups` のルールから除外されます。

### インポート文の順序

この設定に基づいて、インポート文は以下の順序で並びます：

1. **React関連の外部モジュール**（`react`, `@testing-library/**` など）
2. **その他の外部モジュール**（`node_modules` からのもの）
3. **インデックスファイルのインポート**
4. **TypeScriptの型定義のインポート**
5. **`{}` を使用しないその他のインポート**
6. **プロジェクト内のモジュール**（カスタムパスやエイリアスを使用）
7. **同じディレクトリのモジュール**

各グループ内では、インポート文はアルファベット順に並べられます。また、`external` グループ内では `react` および `@testing-library/**` が他の外部モジュールより先に配置されます。

参考URL

- https://www.npmjs.com/package/eslint-plugin-import
- https://github.com/import-js/eslint-plugin-import
- https://zenn.dev/rena_h/scraps/fd330154d02f76
- https://qiita.com/yukiji/items/5ba9e065ac6ed57d05a4
- https://miyahara.hikaru.dev/posts/20200501/
- https://note.com/show_kanamaru/n/n59ee8c96dc30
- https://zenn.dev/riemonyamada/articles/02e8c172e1eeb1