### PR TITLE
#98 Contextを使ってページの値を受け渡す

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-storybook": "^0.6.7",
         "husky": "^8.0.0",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-resolve": "^29.7.0",
@@ -8500,6 +8501,12 @@
       "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
       "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -8707,6 +8714,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ieee754": {
@@ -21490,6 +21509,12 @@
       "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
       "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
+    "harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -21626,6 +21651,15 @@
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ieee754": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-storybook": "^0.6.7",
     "husky": "^8.0.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-resolve": "^29.7.0",

--- a/src/routes/About.test.tsx
+++ b/src/routes/About.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import About from "./About";
+
+describe("初期状態のテスト", () => {
+  const content = render(<About />);
+  it("h1タグがレンダリングされていること", () => {
+    expect(content.getByText("About")).toBeInTheDocument();
+  });
+
+  it("初期状態では名前テキストはレンダリングされていない", () => {
+    const content = render(<About />);
+    expect(content.queryByText("mofu")).toBeNull();
+  });
+
+  it("初期状態ではフォーム内の値は存在しない", () => {
+    const content = render(<About />);
+    expect(content.getByLabelText("Type Your Name")).toHaveValue("");
+  });
+});

--- a/src/routes/About.test.tsx
+++ b/src/routes/About.test.tsx
@@ -2,20 +2,37 @@ import React from "react";
 import { render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import About from "./About";
+import { NameContext } from "./RouterApp";
 
 describe("初期状態のテスト", () => {
-  const content = render(<About />);
+  // Contextのモックを作成
+  const mockSetName = jest.fn();
+  const mockName = "";
+
+  const content = render(
+    <NameContext.Provider value={{ name: mockName, setName: mockSetName }}>
+      <About />
+    </NameContext.Provider>
+  );
   it("h1タグがレンダリングされていること", () => {
     expect(content.getByText("About")).toBeInTheDocument();
   });
 
   it("初期状態では名前テキストはレンダリングされていない", () => {
-    const content = render(<About />);
+    const content = render(
+      <NameContext.Provider value={{ name: mockName, setName: mockSetName }}>
+        <About />
+      </NameContext.Provider>
+    );
     expect(content.queryByText("mofu")).toBeNull();
   });
 
   it("初期状態ではフォーム内の値は存在しない", () => {
-    const content = render(<About />);
+    const content = render(
+      <NameContext.Provider value={{ name: mockName, setName: mockSetName }}>
+        <About />
+      </NameContext.Provider>
+    );
     expect(content.getByLabelText("Type Your Name")).toHaveValue("");
   });
 });

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -13,7 +13,7 @@ export default function About() {
       <h1>About</h1>
       <p>My name is {name}</p>
       <label htmlFor="name">Type Your Name</label>
-      <input id="name" type="text" onInput={handleChange} />
+      <input id="name" type="text" value={name} onInput={handleChange} />
     </>
   );
 }

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -1,5 +1,19 @@
-import React from "react";
+import React, { useState } from "react";
+import "./Root.css";
 
 export default function About() {
-  return <div>About</div>;
+  const [name, setName] = useState("");
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setName(event.target.value);
+  };
+
+  return (
+    <>
+      <h1>About</h1>
+      <p>My name is {name}</p>
+      <label htmlFor="name">Type Your Name</label>
+      <input id="name" type="text" onInput={handleChange} />
+    </>
+  );
 }

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -1,8 +1,14 @@
-import React, { useState } from "react";
+import React from "react";
 import "./Root.css";
+import { NameContext } from "./RouterApp";
 
 export default function About() {
-  const [name, setName] = useState("");
+  const nameContext = React.useContext(NameContext);
+  if (nameContext === undefined) {
+    throw new Error("useCount must be used within a CountProvider");
+  }
+
+  const { name, setName } = nameContext;
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setName(event.target.value);

--- a/src/routes/Article.test.tsx
+++ b/src/routes/Article.test.tsx
@@ -5,15 +5,26 @@ import Article from "./Article";
 import { NameContext } from "./RouterApp";
 
 describe("初期状態のテスト", () => {
-  // Contextのモックを作成
   const mockSetName = jest.fn();
-  const mockName = "name";
   it("ステートが存在する場合はステート + 固定テキストがレンダリングされていること", () => {
+    // Contextのモックを作成
+    const mockName = "name";
     const content = render(
       <NameContext.Provider value={{ name: mockName, setName: mockSetName }}>
         <Article />
       </NameContext.Provider>
     );
     expect(content.getByText("nameのページです")).toBeInTheDocument();
+  });
+
+  it("ステートが存在しない場合は固定テキストのみがレンダリングされていること", () => {
+    // Contextのモックを作成
+    const mockName = "";
+    const content = render(
+      <NameContext.Provider value={{ name: mockName, setName: mockSetName }}>
+        <Article />
+      </NameContext.Provider>
+    );
+    expect(content.getByText("最初のページです")).toBeInTheDocument();
   });
 });

--- a/src/routes/Article.test.tsx
+++ b/src/routes/Article.test.tsx
@@ -7,13 +7,13 @@ import { NameContext } from "./RouterApp";
 describe("初期状態のテスト", () => {
   // Contextのモックを作成
   const mockSetName = jest.fn();
-  const mockName = "";
+  const mockName = "name";
   it("ステートが存在する場合はステート + 固定テキストがレンダリングされていること", () => {
     const content = render(
       <NameContext.Provider value={{ name: mockName, setName: mockSetName }}>
         <Article />
       </NameContext.Provider>
     );
-    expect(content.getByText("最初のページです")).toBeInTheDocument();
+    expect(content.getByText("nameのページです")).toBeInTheDocument();
   });
 });

--- a/src/routes/Article.test.tsx
+++ b/src/routes/Article.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import Article from "./Article";
+import { NameContext } from "./RouterApp";
+
+describe("初期状態のテスト", () => {
+  // Contextのモックを作成
+  const mockSetName = jest.fn();
+  const mockName = "";
+  it("ステートが存在する場合はステート + 固定テキストがレンダリングされていること", () => {
+    const content = render(
+      <NameContext.Provider value={{ name: mockName, setName: mockSetName }}>
+        <Article />
+      </NameContext.Provider>
+    );
+    expect(content.getByText("最初のページです")).toBeInTheDocument();
+  });
+});

--- a/src/routes/Article.tsx
+++ b/src/routes/Article.tsx
@@ -1,7 +1,21 @@
 import React from "react";
 import { useParams } from "react-router-dom";
+import { NameContext } from "./RouterApp";
 
 export default function Article() {
-  const { id = "最初" } = useParams();
-  return <div>{id}のページです</div>;
+  const nameContext = React.useContext(NameContext);
+  const { id = 0 } = useParams();
+  if (nameContext === undefined) {
+    throw new Error("useCount must be used within a CountProvider");
+  }
+
+  const { name } = nameContext;
+
+  return (
+    <>
+      <h1>Article</h1>
+      <p>id: {id}</p>
+      <p>{name}のページです</p>
+    </>
+  );
 }

--- a/src/routes/Article.tsx
+++ b/src/routes/Article.tsx
@@ -15,7 +15,7 @@ export default function Article() {
     <>
       <h1>Article</h1>
       <p>id: {id}</p>
-      <p>{name}のページです</p>
+      <p>{name.length === 0 ? "最初" : name}のページです</p>
     </>
   );
 }

--- a/src/routes/Article.tsx
+++ b/src/routes/Article.tsx
@@ -3,5 +3,5 @@ import { useParams } from "react-router-dom";
 
 export default function Article() {
   const { id = "最初" } = useParams();
-  return <div>{id} のページです</div>;
+  return <div>{id}のページです</div>;
 }

--- a/src/routes/Root.css
+++ b/src/routes/Root.css
@@ -1,0 +1,3 @@
+label {
+  margin-right: 8px;
+}

--- a/src/routes/RouterApp.tsx
+++ b/src/routes/RouterApp.tsx
@@ -2,13 +2,22 @@ import React, { createContext, useState } from "react";
 import { NavLink, Outlet, ScrollRestoration } from "react-router-dom";
 import style from "./RouterApp.module.css";
 
+type NameContextType = {
+  name: string;
+  setName: React.Dispatch<React.SetStateAction<string>>;
+};
+
 // コンテキストを初期化する
-export const NameContext = createContext("");
+export const NameContext = createContext<NameContextType | undefined>(
+  undefined
+);
 
 export default function RouterApp() {
   const [count, setCount] = useState(0);
+  const [name, setName] = useState("");
+
   return (
-    <NameContext.Provider value="">
+    <NameContext.Provider value={{ name, setName }}>
       <>
         <p>アクセス数：{count}</p>
         <ul>

--- a/src/routes/RouterApp.tsx
+++ b/src/routes/RouterApp.tsx
@@ -1,69 +1,74 @@
-import React, { useState } from "react";
+import React, { createContext, useState } from "react";
 import { NavLink, Outlet, ScrollRestoration } from "react-router-dom";
 import style from "./RouterApp.module.css";
+
+// コンテキストを初期化する
+export const NameContext = createContext("");
 
 export default function RouterApp() {
   const [count, setCount] = useState(0);
   return (
-    <>
-      <p>アクセス数：{count}</p>
-      <ul>
-        <li>
-          <NavLink
-            to="/"
-            className={({ isActive }) => (isActive ? style.active : "")}
-            reloadDocument
-          >
-            TopPage
-          </NavLink>
-        </li>
-        <li>
-          <NavLink
-            to="/about"
-            className={({ isActive }) => (isActive ? style.active : "")}
-          >
-            About
-          </NavLink>
-        </li>
-        <li>
-          <NavLink
-            to="/article"
-            className={({ isActive }) => (isActive ? style.active : "")}
-          >
-            さいしょのページ
-          </NavLink>
-        </li>
-        <li>
-          <NavLink
-            to="/article/1"
-            className={({ isActive }) => (isActive ? style.active : "")}
-          >
-            1番のページ
-          </NavLink>
-        </li>
-        <li>
-          <NavLink
-            to="/article/2"
-            preventScrollReset
-            className={({ isActive }) => (isActive ? style.active : "")}
-          >
-            2番のページ
-          </NavLink>
-        </li>
-        <li>
-          <NavLink to="/search/react/router/remix">検索結果</NavLink>
-        </li>
-        <li>
-          <NavLink to="/noting/foo/bar">存在しないページ</NavLink>
-        </li>
-        <li>
-          <NavLink to="/book-query" state="978-4-8156-0182-9">
-            クエリでアクセスするページ
-          </NavLink>
-        </li>
-      </ul>
-      <ScrollRestoration />
-      <Outlet context={[count, setCount]} />
-    </>
+    <NameContext.Provider value="">
+      <>
+        <p>アクセス数：{count}</p>
+        <ul>
+          <li>
+            <NavLink
+              to="/"
+              className={({ isActive }) => (isActive ? style.active : "")}
+              reloadDocument
+            >
+              TopPage
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
+              to="/about"
+              className={({ isActive }) => (isActive ? style.active : "")}
+            >
+              About
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
+              to="/article"
+              className={({ isActive }) => (isActive ? style.active : "")}
+            >
+              さいしょのページ
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
+              to="/article/1"
+              className={({ isActive }) => (isActive ? style.active : "")}
+            >
+              1番のページ
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
+              to="/article/2"
+              preventScrollReset
+              className={({ isActive }) => (isActive ? style.active : "")}
+            >
+              2番のページ
+            </NavLink>
+          </li>
+          <li>
+            <NavLink to="/search/react/router/remix">検索結果</NavLink>
+          </li>
+          <li>
+            <NavLink to="/noting/foo/bar">存在しないページ</NavLink>
+          </li>
+          <li>
+            <NavLink to="/book-query" state="978-4-8156-0182-9">
+              クエリでアクセスするページ
+            </NavLink>
+          </li>
+        </ul>
+        <ScrollRestoration />
+        <Outlet context={[count, setCount]} />
+      </>
+    </NameContext.Provider>
   );
 }

--- a/src/routes/RouterApp.tsx
+++ b/src/routes/RouterApp.tsx
@@ -43,7 +43,7 @@ export default function RouterApp() {
               to="/article"
               className={({ isActive }) => (isActive ? style.active : "")}
             >
-              さいしょのページ
+              ContextでNameを表示するページ
             </NavLink>
           </li>
           <li>


### PR DESCRIPTION
Contextの設定はContextを利用したい一階層上のルートコンポーネント。
なので基本はRoot.tsx的なところと密結合してしまう。

Contextがundefinedのときのケアを考慮する必要がある。ちょっと冗長になりそう。

でもコンポーネントテストはContextをモックアップすればいいので楽。
あとドキュメント内の概念で収まるのも楽。

