### PR TITLE
#10 ユーザーイベントのテスト例を追加

### DIFF
--- a/src/component/ChangeIcon/ChangeIcon.test.tsx
+++ b/src/component/ChangeIcon/ChangeIcon.test.tsx
@@ -19,8 +19,11 @@ it("ドロップダウンの値を変更するとアイコンが変わる", asyn
   const event = userEvent.setup();
   const content = render(<ChangeIcon />);
 
+  // アイコン要素を取得
+  const image = content.getByTestId("icon");
+
   // data-icon属性がimageになっていることを確認
-  expect(content.getByTestId("icon")).toHaveAttribute("data-icon", "music");
+  expect(image).toHaveAttribute("data-icon", "music");
 
   // ドロップダウンの値を変更
   await event.selectOptions(content.getByRole("combobox"), "image");
@@ -30,5 +33,5 @@ it("ドロップダウンの値を変更するとアイコンが変わる", asyn
   ).toBeInTheDocument();
 
   // data-icon属性がimageになっていることを確認
-  expect(content.getByTestId("icon")).toHaveAttribute("data-icon", "image");
+  expect(image).toHaveAttribute("data-icon", "image");
 });

--- a/src/component/ChangeIcon/ChangeIcon.test.tsx
+++ b/src/component/ChangeIcon/ChangeIcon.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
-
+import userEvent from "@testing-library/user-event";
 import ChangeIcon from ".";
 
 it("h2タグが2つ存在する", () => {
@@ -11,6 +11,16 @@ it("h2タグが2つ存在する", () => {
 
 it("アイコン要素が存在することを確認する", () => {
   const content = render(<ChangeIcon />);
+  // アイコン要素が存在することを確認
+  expect(content.getByTestId("icon")).toBeInTheDocument();
+});
+
+it("ドロップダウンの値を変更するとアイコンが変わる", async () => {
+  const event = userEvent.setup();
+  const content = render(<ChangeIcon />);
+
+  // ドロップダウンの値を変更
+  await event.selectOptions(content.getByRole("combobox"), "image");
   // アイコン要素が存在することを確認
   expect(content.getByTestId("icon")).toBeInTheDocument();
 });

--- a/src/component/ChangeIcon/ChangeIcon.test.tsx
+++ b/src/component/ChangeIcon/ChangeIcon.test.tsx
@@ -19,8 +19,16 @@ it("ドロップダウンの値を変更するとアイコンが変わる", asyn
   const event = userEvent.setup();
   const content = render(<ChangeIcon />);
 
+  // data-icon属性がimageになっていることを確認
+  expect(content.getByTestId("icon")).toHaveAttribute("data-icon", "music");
+
   // ドロップダウンの値を変更
   await event.selectOptions(content.getByRole("combobox"), "image");
-  // アイコン要素が存在することを確認
-  expect(content.getByTestId("icon")).toBeInTheDocument();
+  // アイコンのドキュメントが更新されていることを確認
+  expect(
+    content.getByText("選択しているアイコンは画像です")
+  ).toBeInTheDocument();
+
+  // data-icon属性がimageになっていることを確認
+  expect(content.getByTestId("icon")).toHaveAttribute("data-icon", "image");
 });


### PR DESCRIPTION
f42fbb7eb453beb027df1d8b1d808b50611786f3 のように要素の参照でデータをとるとき、落ちるパターンと落ちないパターンがある。違いは何かという部分がまだしっくりきていない。

resolve https://github.com/MofuMofu2/rimarimadan-blog/issues/10