### PR TITLE
#85 コンポーネントからのイベント発火

### DIFF
--- a/src/component/AgreementCheckbox/AgreementCheckbox.test.tsx
+++ b/src/component/AgreementCheckbox/AgreementCheckbox.test.tsx
@@ -37,4 +37,18 @@ describe("チェックボックス操作に関するテストケース", () => {
     // チェック状態がOFFになっていることを確認
     expect(content.getByRole("checkbox")).not.toBeChecked();
   });
+
+  it("チェックボックスをクリックすると親コンポーネントへイベント発火状態を伝えること", async () => {
+    // イベント検知のセットアップ
+    const event = userEvent.setup();
+    // イベントハンドラのモックを用意
+    const handlerMock = jest.fn();
+    const content = render(
+      <AgreementCheckbox onCheckboxStatusChanged={handlerMock} />
+    );
+    // チェックボックスをクリックする
+    await event.click(content.getByRole("checkbox"));
+    // イベントハンドラが呼ばれたことを確認
+    expect(handlerMock).toHaveBeenCalled();
+  });
 });

--- a/src/component/AgreementCheckbox/AgreementCheckbox.tsx
+++ b/src/component/AgreementCheckbox/AgreementCheckbox.tsx
@@ -1,10 +1,19 @@
 import React, { useState } from "react";
 
-export default function AgreementCheckbox() {
+type AgreementCheckboxProps = {
+  onCheckboxStatusChanged?: (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => void;
+};
+
+export default function AgreementCheckbox({
+  onCheckboxStatusChanged,
+}: AgreementCheckboxProps) {
   const [checked, setChecked] = useState(false);
 
-  const handleChecked = () => {
+  const handleChecked = (event: React.ChangeEvent<HTMLInputElement>) => {
     setChecked(!checked);
+    onCheckboxStatusChanged?.(event);
   };
 
   return (


### PR DESCRIPTION
resolve https://github.com/MofuMofu2/rimarimadan-blog/issues/85 


`jest.fn()`を使ってイベント発火したことをモックし、それが呼び出されているかでテストする。
`jest.fn()`は [Jestではじめるテスト入門](https://peaks.cc/books/testing_with_jest) に詳しく解説がある。